### PR TITLE
adding cloudformation templates

### DIFF
--- a/cloudformation/ecr.yaml
+++ b/cloudformation/ecr.yaml
@@ -1,0 +1,26 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Template to deploy the repository into ECR
+Parameters:
+  App:
+    Type: String
+    Description: Application app name
+    Default: sample-app
+
+Resources:
+    ECR:
+      Type: AWS::ECR::Repository
+      Metadata:
+        cfn_nag:
+          rules_to_suppress:
+            - id: W28
+              reason: ECR repository name should be explicit.
+      Properties:
+        RepositoryName: !Sub "ua92/${App}"
+
+Outputs:
+  ECRRepositoryURL:
+    Description: ECR respository URL
+    Value: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECR}"

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -31,7 +31,7 @@ Parameters:
     Description: Container image version / tag
 
 Resources:
-  ListenerHTTPSProductionTraffic:
+  ListenerHTTPTraffic:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
@@ -81,7 +81,7 @@ Resources:
   ECSService:
     Type: AWS::ECS::Service
     DependsOn:
-      - ListenerHTTPSProductionTraffic
+      - ListenerHTTPTraffic
     Properties:
       Cluster: !Ref ClusterName
       TaskDefinition: !Ref TaskDefinition

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1,0 +1,142 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Template to deploy the sample app into ECS behind an ALB.
+Parameters:
+  App:
+    Type: String
+    Description: Application app name
+    Default: sample-app
+  VpcId:
+    Type: String
+    Description: VPC ID
+  SubnetA:
+    Type: String
+    Description: Subnet in availability zone a
+  SubnetB:
+    Type: String
+    Description: Subnet in availability zone b
+  SubnetC:
+    Type: String
+    Description: Subnet in availability zone c
+  ClusterName:
+    Type: String
+    Description: Cluster name
+  ALBSecurityGroup:
+    Type: String
+    Description: ALB security group
+  Version:
+    Type: String
+    Description: Container image version / tag
+
+Resources:
+  ListenerHTTPSProductionTraffic:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internal
+      SecurityGroups:
+        - !Ref ALBSecurityGroup
+      Subnets: 
+        - !Ref SubnetA
+        - !Ref SubnetB
+        - !Ref SubnetC
+      Type: application
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn:
+      - ApplicationLoadBalancer
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthyThresholdCount: 5
+      UnhealthyThresholdCount: 5
+      HealthCheckTimeoutSeconds: 2
+      Port: 8000
+      Protocol: HTTP
+      TargetType: ip
+      TargetGroupAttributes:
+        - Key: load_balancing.algorithm.type
+          Value: least_outstanding_requests
+      VpcId:
+        !Ref VpcId
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/ua92/${App}'
+
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - ListenerHTTPSProductionTraffic
+    Properties:
+      Cluster: !Ref ClusterName
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: !Ref App
+          ContainerPort: 8000
+          TargetGroupArn: !Ref TargetGroup
+      HealthCheckGracePeriodSeconds: 5
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !Ref TaskSecurityGroup
+          Subnets: 
+            - !Ref SubnetA
+            - !Ref SubnetB
+            - !Ref SubnetC
+      PlatformVersion: "1.4.0"
+      SchedulingStrategy: REPLICA
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Cpu: '256'
+      Memory: '512'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: arn:aws:iam::244156612332:role/ecsTaskExecutionRole
+      ContainerDefinitions:
+        - Name: !Ref App
+          Cpu: 256
+          Memory: 512
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/ua92/${App}:${Version}"
+          PortMappings:
+            - ContainerPort: 8000
+              HostPort: 8000
+              Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "Traffic rules for ${App} ecs task ingress"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8000
+          ToPort: 8000
+          SourceSecurityGroupId: !Ref ALBSecurityGroup
+          Description: !Sub "Allow port 8000/tcp from ALB to ${App}"
+


### PR DESCRIPTION
Two templates, one to create ECR. The other creates:

- ALB
- Listener
- Target Group
- Task Definition
- Service
- Log Group
- Security Group for ALB Ingress

Assuming that the account will already have a default VPC, 3xsubnets, a default security group and a ECS cluster set up. Made this assumption if there was a shared account being deployed to, though I can add templates for creating these as well.